### PR TITLE
fix: fix guidebook not acessible due to string error link declaration

### DIFF
--- a/src/app/(site)/events/ptc/link-client.tsx
+++ b/src/app/(site)/events/ptc/link-client.tsx
@@ -11,7 +11,7 @@ function LinkPTCCLient() {
       href={
         session?.user.ticket?.PTC.verified === 'verified'
           ? 'https://drive.google.com/file/d/1t4HAvE1Xvh3sLA8vl9yHN_gL42B93BD-/view?usp=sharing'
-          : "'https://drive.google.com/drive/folders/1BRnRPJV18QAmtyLj-CJkmXFafEXyhyUU?usp=drive_link'"
+          : 'https://drive.google.com/drive/folders/1BRnRPJV18QAmtyLj-CJkmXFafEXyhyUU?usp=drive_link'
       }
     >
       <Button color='gold' isFullWidth>


### PR DESCRIPTION
# Description

Fix guidebook link acces on PTC page

# Screenshots

please include screenshots if you have any relevant change to the UI
